### PR TITLE
Enhance easynews handling and add encryption CLI

### DIFF
--- a/CONFIGURING.md
+++ b/CONFIGURING.md
@@ -37,8 +37,8 @@
 | `DEFAULT_TORBOX_TIMEOUT`           | `15000`                                              | Default timeout for Torbox requests (in milliseconds).                                   |
 | `DEFAULT_COMET_TIMEOUT`            | `15000`                                              | Default timeout for Comet requests (in milliseconds).                                    |
 | `DEFAULT_MEDIAFUSION_TIMEOUT`      | `15000`                                              | Default timeout for MediaFusion requests (in milliseconds).                              |
-| `DEFAULT_EASYNEWS_TIMEMOUT`        | `15000`                                              | Default timeout for Easynews requests (in milliseconds).                                 |
-| `DEFAULT_EASYNEWS_PLUS_TIMEMOUT`   | `15000`                                              | Default timeout for Easynews Plus requests (in milliseconds).                            |
+| `DEFAULT_EASYNEWS_TIMEOUT` *(or `DEFAULT_EASYNEWS_TIMEMOUT`)*        | `15000`                                              | Default timeout for Easynews requests (in milliseconds).                                 |
+| `DEFAULT_EASYNEWS_PLUS_TIMEOUT` *(or `DEFAULT_EASYNEWS_PLUS_TIMEMOUT`)*   | `15000`                                              | Default timeout for Easynews Plus requests (in milliseconds).                            |
 | `SHOW_DIE`                         | `true`                                               | Whether to display the die emoji in AIOStreams results                                                          |
 | `LOG_SENSITIVE_INFO`               | `false`                                              | Whether to log sensitive information.                                                      |
 | `DISABLE_TORRENTIO`                | `false`                                              | Whether to disable adding Torrentio as an addon, through override URLs, custom addons, or through the public ElfHosted instance of StremThru | 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ Most users don't need to set any environment variables. However, if you do, the 
 
 With encryption, someone who has your manifest URL can't directly see your API keys. However, they can still install the addon using the encrypted URL. Once installed, they can view API keys within other addons' URLs that are contained within AIOStreams' responses, as most addons don’t encrypt their manifest URLs.
 
+### Encryption CLI
+
+After building the project you can generate an encrypted configuration string without running the server.
+
+```bash
+node packages/utils/dist/encrypt-config.js path/to/config.json
+```
+
+The printed string can be used wherever an encrypted configuration is required.
+
 ### Environment Variables
 
 Please see [CONFIGURING](CONFIGURING.md) and the [sample .env file](.env.sample) for a list of environment variables that can be set.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,9 @@
   "name": "@aiostreams/utils",
   "version": "1.14.2",
   "main": "./dist/index.js",
+  "bin": {
+    "encrypt-config": "./dist/encrypt-config.js"
+  },
   "scripts": {
     "test": "vitest run --passWithNoTests",
     "build": "tsc"

--- a/packages/utils/src/encrypt-config.ts
+++ b/packages/utils/src/encrypt-config.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { minifyConfig, crushJson, compressData, encryptData, Settings } from './index';
+
+const path = process.argv[2];
+if (!path) {
+  console.error('Usage: encrypt-config <path-to-json>');
+  process.exit(1);
+}
+
+try {
+  const file = readFileSync(path, 'utf-8');
+  const minified = minifyConfig(JSON.parse(file));
+  const crushed = crushJson(JSON.stringify(minified));
+  const compressed = compressData(crushed);
+
+  let output: string;
+  if (!Settings.SECRET_KEY) {
+    output = `B-${encodeURIComponent(compressed.toString('base64'))}`;
+  } else {
+    const { iv, data } = encryptData(compressed);
+    output = `E2-${encodeURIComponent(iv)}-${encodeURIComponent(data)}`;
+  }
+  console.log(output);
+} catch (err: any) {
+  console.error('Failed to encrypt configuration:', err.message);
+  process.exit(1);
+}

--- a/packages/utils/src/settings.ts
+++ b/packages/utils/src/settings.ts
@@ -193,18 +193,27 @@ export class Settings {
   public static readonly EASYNEWS_URL =
     process.env.EASYNEWS_URL ||
     'https://ea627ddf0ee7-easynews.baby-beamup.club/';
-  public static readonly DEFAULT_EASYNEWS_TIMEMOUT = process.env
-    .DEFAULT_EASYNEWS_TIMEMOUT
+  public static readonly DEFAULT_EASYNEWS_TIMEOUT = process.env.DEFAULT_EASYNEWS_TIMEOUT
+    ? parseInt(process.env.DEFAULT_EASYNEWS_TIMEOUT)
+    : process.env.DEFAULT_EASYNEWS_TIMEMOUT
     ? parseInt(process.env.DEFAULT_EASYNEWS_TIMEMOUT)
     : undefined;
+  /** @deprecated Use DEFAULT_EASYNEWS_TIMEOUT */
+  public static readonly DEFAULT_EASYNEWS_TIMEMOUT =
+    Settings.DEFAULT_EASYNEWS_TIMEOUT;
 
   public static readonly EASYNEWS_PLUS_URL =
     process.env.EASYNEWS_PLUS_URL ||
     'https://b89262c192b0-stremio-easynews-addon.baby-beamup.club/';
-  public static readonly DEFAULT_EASYNEWS_PLUS_TIMEMOUT = process.env
-    .DEFAULT_EASYNEWS_PLUS_TIMEMOUT
-    ? parseInt(process.env.DEFAULT_EASYNEWS_PLUS_TIMEMOUT)
-    : undefined;
+  public static readonly DEFAULT_EASYNEWS_PLUS_TIMEOUT =
+    process.env.DEFAULT_EASYNEWS_PLUS_TIMEOUT
+      ? parseInt(process.env.DEFAULT_EASYNEWS_PLUS_TIMEOUT)
+      : process.env.DEFAULT_EASYNEWS_PLUS_TIMEMOUT
+      ? parseInt(process.env.DEFAULT_EASYNEWS_PLUS_TIMEMOUT)
+      : undefined;
+  /** @deprecated Use DEFAULT_EASYNEWS_PLUS_TIMEOUT */
+  public static readonly DEFAULT_EASYNEWS_PLUS_TIMEMOUT =
+    Settings.DEFAULT_EASYNEWS_PLUS_TIMEOUT;
 
   public static readonly DEBRIDIO_URL =
     process.env.DEBRIDIO_URL || 'https://debridio.adobotec.com/';

--- a/packages/wrappers/src/__tests__/base.test.ts
+++ b/packages/wrappers/src/__tests__/base.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { BaseWrapper } from '../base';
+import type { Config } from '@aiostreams/types';
+
+class TestWrapper extends BaseWrapper {
+  constructor() {
+    const cfg = {
+      resolutions: [],
+      qualities: [],
+      visualTags: [],
+      audioTags: [],
+      encodes: [],
+      sortBy: [],
+      streamTypes: [],
+      onlyShowCachedStreams: false,
+      prioritisedLanguages: null,
+      excludedLanguages: null,
+      formatter: '',
+    } as unknown as Config;
+    super('test', 'http://example.com/manifest.json', 'test', cfg);
+  }
+
+  public parseSize(str: string, k = 1024) {
+    return this.extractSizeInBytes(str, k);
+  }
+}
+
+describe('extractSizeInBytes', () => {
+  const wrapper = new TestWrapper();
+  it('parses KB/MB/GB/TB values', () => {
+    expect(wrapper.parseSize('1KB')).toBe(1024);
+    expect(wrapper.parseSize('1.5 MB')).toBe(1.5 * 1024 * 1024);
+    expect(wrapper.parseSize('2GB')).toBe(2 * 1024 * 1024 * 1024);
+    expect(wrapper.parseSize('3 TB')).toBe(3 * 1024 ** 4);
+  });
+
+  it('returns 0 when no match', () => {
+    expect(wrapper.parseSize('unknown')).toBe(0);
+  });
+});

--- a/packages/wrappers/src/base.ts
+++ b/packages/wrappers/src/base.ts
@@ -467,7 +467,7 @@ export class BaseWrapper {
   }
 
   protected extractSizeInBytes(string: string, k: number): number {
-    const sizePattern = /(\d+(\.\d+)?)\s?(KB|MB|GB)/i;
+    const sizePattern = /(\d+(\.\d+)?)\s?(KB|MB|GB|TB)/i;
     const match = string.match(sizePattern);
     if (!match) return 0;
 

--- a/packages/wrappers/src/easynews.ts
+++ b/packages/wrappers/src/easynews.ts
@@ -23,7 +23,7 @@ export class Easynews extends BaseWrapper {
       url,
       addonId,
       userConfig,
-      indexerTimeout || Settings.DEFAULT_EASYNEWS_TIMEMOUT
+      indexerTimeout || Settings.DEFAULT_EASYNEWS_TIMEOUT
     );
   }
 

--- a/packages/wrappers/src/easynewsPlus.ts
+++ b/packages/wrappers/src/easynewsPlus.ts
@@ -23,7 +23,7 @@ export class EasynewsPlus extends BaseWrapper {
       url,
       addonId,
       userConfig,
-      indexerTimeout || Settings.DEFAULT_EASYNEWS_PLUS_TIMEMOUT
+      indexerTimeout || Settings.DEFAULT_EASYNEWS_PLUS_TIMEOUT
     );
   }
 


### PR DESCRIPTION
## Summary
- support TB in size regex
- fix DEFAULT_EASYNEWS_TIMEOUT env names
- add encrypt-config CLI utility
- update docs for the new variables and CLI
- add tests for size parsing

## Testing
- `npm -w packages/wrappers test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f861bedb0832e9cb973c03d176878