### PR TITLE
Optimize Heroku slug size

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,18 @@
+# Exclude documentation and configs
+*.md
+Dockerfile
+compose.yaml
+release-please-config.json
+.release-please-manifest.json
+.prettierrc
+.vscode
+.github
+
+# Exclude source and test files
+packages/*/src
+packages/*/tests
+scripts
+
+# Exclude TypeScript config and build info
+**/*.tsbuildinfo
+tsconfig*.json

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start:addon": "npm run start",
     "start:dev": "cross-env NODE_ENV=development tsx watch packages/server/src/server.ts",
     "start:addon:dev": "npm run start:dev",
-    "start:frontend:dev": "npm -w packages/frontend run dev"
+    "start:frontend:dev": "npm -w packages/frontend run dev",
+    "heroku-postbuild": "npm run build && npm prune --production"
   },
   "author": "Viren070",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- ignore extraneous files when building the Heroku slug
- run `npm prune --production` after build to remove dev dependencies

## Testing
- `npm test` *(fails: missing frontend test script)*

------
https://chatgpt.com/codex/tasks/task_e_68689a9ec35c832e80e4ab0ecfe0979b