### PR TITLE
Add cache management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@
 
 ## ✨ What is AIOStreams?
 
-AIOStreams was created to give users ultimate control over their Stremio experience. Instead of juggling multiple addons with different configurations and limitations, AIOStreams acts as a central hub. It fetches results from all your favorite sources, then filters, sorts, and formats them according to *your* rules before presenting them in a single, clean list.
+AIOStreams was created to give users ultimate control over their Stremio experience. Instead of juggling multiple addons with different configurations and limitations, AIOStreams acts as a central hub. It fetches results from all your favorite sources, then filters, sorts, and formats them according to _your_ rules before presenting them in a single, clean list.
 
 Whether you're a casual user who wants a simple, unified stream list or a power user who wants to fine-tune every aspect of your results, AIOStreams has you covered.
-
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/6179efdb-abc9-4e0c-ae11-fb0e3ca9606a" alt="AIOStreams in action"  width="750" />
@@ -44,10 +43,11 @@ Whether you're a casual user who wants a simple, unified stream list or a power 
 ## 🚀 Key Features
 
 ### 🔌 All Your Addons, One Interface
+
 - **Unified Results**: Aggregate streams from multiple addons into one consistently sorted and formatted list.
 - **Simplified Addon Management**: AIOStreams features a built-in addon marketplace. Many addons require you to install them multiple times to support different debrid services. AIOStreams handles this automatically. Just enable an addon from the marketplace, and AIOStreams dynamically applies your debrid keys, so you only have to configure it once.
 - **Automatic Updates**: Because addon manifests are generated dynamically, you get the latest updates and fixes without ever needing to reconfigure or reinstall.
-- **Custom Addon Support**: Add *any* Stremio addon by providing its configured URL. If it works in Stremio, it works here.
+- **Custom Addon Support**: Add _any_ Stremio addon by providing its configured URL. If it works in Stremio, it works here.
 - **Full Stremio Support**: AIOStreams doesn't just manage streams; it supports all Stremio resources, including catalogs, metadata, and even addon catalogs.
 
 <p align="center">
@@ -55,25 +55,28 @@ Whether you're a casual user who wants a simple, unified stream list or a power 
 </p>
 
 ### 🔬 Advanced Filtering & Sorting Engine
+
 Because all addons are routed through AIOStreams, you only have to **configure your filters and sorting rules once**. This powerful, centralized engine offers far more options and flexibility than any individual addon.
 
 - **Granular Filtering**: Define `include` (prevents filtering), `required`, or `excluded` rules for a huge range of properties:
-    - **Video/Audio**: Resolution, quality, encodes, visual tags (`HDR`, `DV`), audio tags (`Atmos`), and channels.
-    - **Source**: Stream type (`Debrid`, `Usenet`, `P2P`), language, seeder ranges, and cached/uncached status (can be applied to specific addons/services).
+  - **Video/Audio**: Resolution, quality, encodes, visual tags (`HDR`, `DV`), audio tags (`Atmos`), and channels.
+  - **Source**: Stream type (`Debrid`, `Usenet`, `P2P`), language, seeder ranges, and cached/uncached status (can be applied to specific addons/services).
 - **Preferred Lists**: Manually define and order a list of preferred properties to prioritize certain results, for example, always showing `HDR` streams first.
 - **Keyword & Regex Filtering**: Filter by simple keywords or complex regex patterns matched against filenames, indexers and release groups for ultimate precision.
 - **Accurate Title Matching**: Leverages the TMDB API to precisely match titles, years, and season/episode numbers, ensuring you always get the right content. This can be granularly applied to specific addons or content types.
 - **Powerful Conditional Engine**: Create dynamic rules with a simple yet powerful expression language.
-    - *Example*: Only exclude 720p streams if more than five 1080p streams are available: `count(resolution(streams, '1080p')) > 5 ? resolution(streams, '720p') : false`.
-    - Check the wiki for a [full function reference](https://github.com/Viren070/AIOStreams/wiki/Stream-Expression-Language).
+  - _Example_: Only exclude 720p streams if more than five 1080p streams are available: `count(resolution(streams, '1080p')) > 5 ? resolution(streams, '720p') : false`.
+  - Check the wiki for a [full function reference](https://github.com/Viren070/AIOStreams/wiki/Stream-Expression-Language).
 - **Customisable Deduplication**: Choose how duplicate streams are detected: by filename, infohash, and a unique "smart detect" hash generated from certain file attributes.
 - **Sophisticated Sorting**:
-    - Build your perfect sort order using any combination of criteria.
-    - Define separate sorting logic for movies, series, anime, and even for cached vs. uncached results.
-    - The sorting system automatically uses the rankings from your "Preferred Lists".
+  - Build your perfect sort order using any combination of criteria.
+  - Define separate sorting logic for movies, series, anime, and even for cached vs. uncached results.
+  - The sorting system automatically uses the rankings from your "Preferred Lists".
 
 ### 🗂️ Unified Catalog Management
+
 Take control of your Stremio home page. AIOStreams lets you manage catalogs from all your addons in one place.
+
 - **Rename**: Rename both the name and the type of the catalog to whatever you want. (e.g. Changing Cinemeta's `Popular - Movies` to `Popular - 📺`)
 - **Reorder & Disable**: Arrange catalogs in your preferred order or hide the ones you don't use.
 - **Shuffle Catalogs**: Discover new content by shuffling the results of any catalog. You can even persist the shuffle for a set period.
@@ -85,11 +88,11 @@ Take control of your Stremio home page. AIOStreams lets you manage catalogs from
 </p>
 
 ### 🎨 Total Customization
+
 - **Custom Stream Formatting**: Design exactly how stream information is displayed using a powerful templating system.
 - **Live Preview**: See your custom format changes in real-time as you build them.
 - **Predefined Formats**: Get started quickly with built-in formats, some created by me and others inspired by other popular addons like Torrentio and the TorBox Stremio Addon.
 - **[Custom Formatter Wiki](https://github.com/Viren070/AIOStreams/wiki/Custom-Formatter)**: Dive deep into the documentation to create your perfect stream title.
-
 
 <p align="center">
   <img src="https://github.com/user-attachments/assets/906cc3fc-16d1-4702-99c7-425b2445387b" alt="Custom Formatter UI" width="750"/>
@@ -102,8 +105,8 @@ Take control of your Stremio home page. AIOStreams lets you manage catalogs from
   </sub>
 </p>
 
-
 ### 🛡️ Proxy & Performance
+
 - **Proxy Integration**: Seamlessly proxy streams through **[MediaFlow Proxy](https://github.com/mhdzumair/mediaflow-proxy)** or **[StremThru](https://github.com/MunifTanjim/stremthru)**.
 - **Bypass IP Restrictions**: Essential for services that limit simultaneous connections from different IP addresses.
 - **Improve Compatibility**: Fixes playback issues with certain players (like Infuse) and addons.
@@ -115,10 +118,12 @@ And much much more...
 Setting up AIOStreams is simple.
 
 1.  **Choose a Hosting Method**
+
     - **🔓 Public Instance**: Use the **[Community Instance (Hosted by ElfHosted)](https://aiostreams.elfhosted.com/configure)**. It's free, but rate-limited and has Torrentio disabled.
     - **🛠️ Self-Host / Paid Hosting**: For full control and no rate limits, host it yourself (Docker) or use a paid service like **[ElfHosted](https://store.elfhosted.com/product/aiostreams/elf/viren070/)** (using this link supports the project!).
 
 2.  **Configure Your Addon**
+
     - Open the `/stremio/configure` page of your AIOStreams instance in a web browser.
     - Enable the addons you use, add your debrid API keys, and set up your filtering, sorting, and formatting rules.
 
@@ -126,8 +131,19 @@ Setting up AIOStreams is simple.
     - Click the "Install" button. This will open your Stremio addon compatible app and add your newly configured AIOStreams addon.
 
 For detailed instructions, check out the Wiki:
+
 - **[Deployment Guide](https://github.com/Viren070/AIOStreams/wiki/Deployment)**
 - **[Configuration Guide](https://github.com/Viren070/AIOStreams/wiki/Configuration)**
+
+## API Endpoints
+
+### `GET /api/v1/cache/stats`
+
+Returns statistics for all cache instances.
+
+### `POST /api/v1/cache/clear`
+
+Clears all cache instances. Provide `?name=cacheName` to clear a specific cache.
 
 ---
 
@@ -152,7 +168,7 @@ AIOStreams is a tool for aggregating and managing data from other Stremio addons
 
 This project wouldn't be possible without the foundational work of many others in the community, especially those who develop the addons that AIOStreams integrates. Special thanks to the developers of all the integrated addons, the creators of [mhdzumair/mediaflow-proxy](https://github.com/mhdzumair/mediaflow-proxy) and [MunifTanjim/stremthru](https://github.com/MunifTanjim/stremthru), and the open-source projects that inspired parts of AIOStreams' design:
 
-* UI Components and issue templates adapted with permission from [5rahim/seanime](https://github.com/5rahim/seanime) (which any anime enthusiast should definitely check out!)
-* [sleeyax/stremio-easynews-addon](https://github.com/sleeyax/stremio-easynews-addon) for the projects initial structure
-* Custom formatter system inspired by and adapted from [diced/zipline](https://github.com/diced/zipline).
-* Condition engine powered by [expr-eval](https://github.com/silentmatt/expr-eval)
+- UI Components and issue templates adapted with permission from [5rahim/seanime](https://github.com/5rahim/seanime) (which any anime enthusiast should definitely check out!)
+- [sleeyax/stremio-easynews-addon](https://github.com/sleeyax/stremio-easynews-addon) for the projects initial structure
+- Custom formatter system inspired by and adapted from [diced/zipline](https://github.com/diced/zipline).
+- Condition engine powered by [expr-eval](https://github.com/silentmatt/expr-eval)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,6 +1755,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1836,6 +1849,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3707,6 +3730,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3796,6 +3826,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -3924,6 +3961,30 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -4983,6 +5044,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5017,9 +5085,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -5720,8 +5786,6 @@
       "version": "1.0.8",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5747,6 +5811,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/concat-map": {
@@ -5795,6 +5869,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/create-require": {
@@ -6060,8 +6141,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6119,6 +6198,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/didyoumean": {
@@ -7137,6 +7227,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -7300,8 +7397,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7310,6 +7405,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -12487,6 +12600,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.1.tgz",
+      "integrity": "sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.1.tgz",
+      "integrity": "sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14679,7 +14840,9 @@
       "devDependencies": {
         "@types/express": "^5.0.1",
         "@types/express-rate-limit": "^5.1.3",
-        "@types/node": "^20.14.10"
+        "@types/node": "^20.14.10",
+        "@types/supertest": "^6.0.3",
+        "supertest": "^7.1.1"
       }
     }
   }

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -98,6 +98,18 @@ export class Cache<K, V> {
   }
 
   /**
+   * Clear all cache instances completely.
+   */
+  public static clearAllInstances() {
+    if (this.instances.size === 0) {
+      return;
+    }
+    for (const cache of this.instances.values()) {
+      cache.clear();
+    }
+  }
+
+  /**
    * Gets the statistics of the cache in use by the program. returns a formatted string containing a list of all cache instances
    * and their currently held items, max items
    */
@@ -148,6 +160,37 @@ export class Cache<K, V> {
 
     const lines = [...header, ...bodyLines, ...footer];
     logger.verbose(lines.join('\n'));
+  }
+
+  /**
+   * Return cache statistics in raw object form for each instance.
+   */
+  public static getStatsObject() {
+    const stats: Array<{
+      name: string;
+      itemCount: number;
+      maxSize: number;
+      estimatedSize: number;
+    }> = [];
+
+    for (const [name, cache] of this.instances.entries()) {
+      let instanceSize = 0;
+      for (const item of cache.cache.values()) {
+        try {
+          instanceSize += Buffer.byteLength(JSON.stringify(item), 'utf8');
+        } catch {
+          instanceSize += 0;
+        }
+      }
+      stats.push({
+        name,
+        itemCount: cache.cache.size,
+        maxSize: cache.maxSize,
+        estimatedSize: instanceSize,
+      });
+    }
+
+    return stats;
   }
 
   /**

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -42,6 +42,13 @@ export class Cache<K, V> {
       }
     }
   }
+
+  /**
+   * Manually trigger cleanup of expired items in this instance.
+   */
+  public cleanup() {
+    this.cleanupExpired();
+  }
   private static startStatsLoop() {
     if (Cache.isStatsLoopRunning) {
       return;
@@ -49,7 +56,7 @@ export class Cache<K, V> {
     Cache.isStatsLoopRunning = true;
     const interval = Env.LOG_CACHE_STATS_INTERVAL * 60 * 1000; // Convert minutes to ms
     const runAndReschedule = () => {
-      Cache.cleanupAll();
+      Cache.cleanupAllInstances();
       Cache.stats();
 
       const delay = interval - (Date.now() % interval);
@@ -75,7 +82,10 @@ export class Cache<K, V> {
     return this.instances.get(name) as Cache<K, V>;
   }
 
-  private static cleanupAll() {
+  /**
+   * Clean up expired items in all cache instances.
+   */
+  public static cleanupAllInstances() {
     for (const cache of this.instances.values()) {
       cache.cleanupExpired();
     }

--- a/packages/core/src/utils/cache.ts
+++ b/packages/core/src/utils/cache.ts
@@ -35,6 +35,9 @@ export class Cache<K, V> {
     Cache.startStatsLoop();
   }
   private cleanupExpired() {
+    if (this.cache.size === 0) {
+      return;
+    }
     const now = Date.now();
     for (const [key, item] of this.cache.entries()) {
       if (now - item.lastAccessed > item.ttl) {
@@ -86,6 +89,9 @@ export class Cache<K, V> {
    * Clean up expired items in all cache instances.
    */
   public static cleanupAllInstances() {
+    if (this.instances.size === 0) {
+      return;
+    }
     for (const cache of this.instances.values()) {
       cache.cleanupExpired();
     }
@@ -224,6 +230,9 @@ export class Cache<K, V> {
   }
 
   private evict(): void {
+    if (this.cache.size === 0) {
+      return;
+    }
     let oldestKey: K | undefined;
     let oldestTime = Infinity;
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -366,7 +366,6 @@ export const Env = cleanEnv(process.env, {
     default: 15,
     desc: 'Max number of addons',
   }),
-  // TODO
   MAX_KEYWORD_FILTERS: num({
     default: 30,
     desc: 'Max number of keyword filters',

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -339,6 +339,10 @@ export const Env = cleanEnv(process.env, {
     default: -1,
     desc: 'Cache TTL for stream files. If -1, no caching will be done.',
   }),
+  STREAM_CACHE_REFRESH_COUNT: num({
+    default: 0,
+    desc: 'Number of times to refresh stream cache when it expires',
+  }),
   CATALOG_CACHE_TTL: num({
     default: 300,
     desc: 'Cache TTL for catalog files',

--- a/packages/core/src/utils/startup.ts
+++ b/packages/core/src/utils/startup.ts
@@ -144,6 +144,12 @@ const logStartupInfo = () => {
       logKeyValue('Stream Cache:', '❌ DISABLED');
     } else {
       logKeyValue('Stream TTL:', formatDuration(Env.STREAM_CACHE_TTL));
+      if (Env.STREAM_CACHE_REFRESH_COUNT > 0) {
+        logKeyValue(
+          'Stream Refresh Count:',
+          String(Env.STREAM_CACHE_REFRESH_COUNT)
+        );
+      }
     }
 
     // Subtitle Cache

--- a/packages/core/tests/cache.test.ts
+++ b/packages/core/tests/cache.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+// set required env vars before importing the cache module
+process.env.SECRET_KEY = 'a'.repeat(64)
+process.env.BASE_URL = 'http://localhost'
+
+describe('Cache', () => {
+  it('removes expired entries on access', async () => {
+    const { Cache } = await import('../src/utils/cache')
+    const cache = Cache.getInstance<string, number>('test-cache')
+    cache.set('foo', 123, 0.05)
+    expect(cache.get('foo')).toBe(123)
+    await new Promise(r => setTimeout(r, 60))
+    expect(cache.get('foo')).toBeUndefined()
+  })
+})

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,8 @@
   "devDependencies": {
     "@types/express": "^5.0.1",
     "@types/express-rate-limit": "^5.1.3",
-    "@types/node": "^20.14.10"
+    "@types/node": "^20.14.10",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.1.1"
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -6,6 +6,7 @@ import {
   statusApi,
   formatApi,
   catalogApi,
+  cacheApi,
 } from './routes/api';
 import {
   configure,
@@ -54,6 +55,7 @@ apiRouter.use('/health', healthApi);
 apiRouter.use('/status', statusApi);
 apiRouter.use('/format', formatApi);
 apiRouter.use('/catalogs', catalogApi);
+apiRouter.use('/cache', cacheApi);
 app.use(`/api/v${constants.API_VERSION}`, apiRouter);
 
 // Stremio Routes

--- a/packages/server/src/routes/api/cache.ts
+++ b/packages/server/src/routes/api/cache.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { createResponse } from '../../utils/responses';
+import { Cache } from '@aiostreams/core';
+import { APIError, constants } from '@aiostreams/core';
+
+const router = Router();
+
+router.get('/stats', (req: Request, res: Response) => {
+  const stats = Cache.getStatsObject();
+  res.status(200).json(createResponse({ success: true, data: stats }));
+});
+
+router.post('/clear', (req: Request, res: Response, next: NextFunction) => {
+  const { name } = req.query;
+  if (name && typeof name !== 'string') {
+    next(
+      new APIError(
+        constants.ErrorCode.MISSING_REQUIRED_FIELDS,
+        undefined,
+        'name must be a string'
+      )
+    );
+    return;
+  }
+
+  if (typeof name === 'string') {
+    const exists = Cache.getStatsObject().some((s) => s.name === name);
+    if (exists) {
+      Cache.getInstance(name).clear();
+    }
+  } else {
+    Cache.clearAllInstances();
+  }
+
+  res.status(200).json(createResponse({ success: true }));
+});
+
+export default router;

--- a/packages/server/src/routes/api/index.ts
+++ b/packages/server/src/routes/api/index.ts
@@ -3,3 +3,4 @@ export { default as healthApi } from './health';
 export { default as statusApi } from './status';
 export { default as formatApi } from './format';
 export { default as catalogApi } from './catalog';
+export { default as cacheApi } from './cache';

--- a/packages/server/tests/cacheRoutes.test.ts
+++ b/packages/server/tests/cacheRoutes.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+
+process.env.SECRET_KEY = 'a'.repeat(64);
+process.env.BASE_URL = 'http://localhost';
+
+let app: any;
+let Cache: any;
+
+describe('Cache API', () => {
+  beforeEach(async () => {
+    const cacheMod = await import('../../core/src/utils/cache');
+    Cache = cacheMod.Cache;
+    const appMod = await import('../src/app');
+    app = appMod.default;
+    Cache.clearAllInstances();
+  });
+
+  it('returns cache stats and clears caches', async () => {
+    const cacheA = Cache.getInstance<string, number>('test');
+    cacheA.set('foo', 1, 10);
+
+    let res = await request(app).get('/api/v1/cache/stats');
+    expect(res.statusCode).toBe(200);
+    const entry = res.body.data.find((s: any) => s.name === 'test');
+    expect(entry.itemCount).toBe(1);
+
+    await request(app).post('/api/v1/cache/clear').query({ name: 'test' });
+
+    res = await request(app).get('/api/v1/cache/stats');
+    const cleared = res.body.data.find((s: any) => s.name === 'test');
+    expect(cleared.itemCount).toBe(0);
+
+    Cache.getInstance<string, number>('test2').set('bar', 2, 10);
+    await request(app).post('/api/v1/cache/clear');
+
+    res = await request(app).get('/api/v1/cache/stats');
+    expect(res.body.data.every((s: any) => s.itemCount === 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expose cache stats & reset functions in cache utility
- add new cache API route
- wire cache routes in server app
- document cache endpoints
- test cache route functionality

## Testing
- `npx -y vitest@2.1.5 run --passWithNoTests --root packages/core`
- `npx -y vitest@2.1.5 run --passWithNoTests --root packages/server` *(fails: Error loading metadata.json)*

------
https://chatgpt.com/codex/tasks/task_e_686898ce25e4832ead0fe8e8a857faa2